### PR TITLE
Fix bad validation logic

### DIFF
--- a/lib/fastlane/plugin/branch/helper/branch_helper.rb
+++ b/lib/fastlane/plugin/branch/helper/branch_helper.rb
@@ -174,7 +174,7 @@ module Fastlane
             # TODO: Support URI schemes for iOS?
             next if domain =~ /\.test-app\.link$/
             domain_valid = validate_team_and_bundle_ids project, target_name, domain, configuration
-            valid ||= domain_valid
+            valid &&= domain_valid
             UI.message "Valid Universal Link configuration for #{domain} ✅" if domain_valid
           end
           valid

--- a/spec/branch_helper_spec.rb
+++ b/spec/branch_helper_spec.rb
@@ -221,6 +221,28 @@ describe Fastlane::Helper::BranchHelper do
     end
   end
 
+  describe '#validate_team_and_bundle_ids_from_aasa_files' do
+    it 'only succeeds if all domains are valid' do
+      project = double "project"
+
+      # No domains in project. Just validating what's passed in.
+      expect(helper).to receive(:domains_from_project) { [] }
+      # example.com is valid
+      expect(helper).to receive(:validate_team_and_bundle_ids)
+        .with(project, nil, "example.com", "Release") { true }
+      # www.example.com is not valid
+      expect(helper).to receive(:validate_team_and_bundle_ids)
+        .with(project, nil, "www.example.com", "Release") { false }
+
+      valid = helper.validate_team_and_bundle_ids_from_aasa_files(
+        project,
+        nil,
+        %w{example.com www.example.com}
+      )
+      expect(valid).to be false
+    end
+  end
+
   def mock_http_request(mock_response)
     mock_http = double "http", peer_cert: nil
     expect(mock_http).to receive(:request).at_least(:once) { mock_response }


### PR DESCRIPTION
Multiple domains were validated with an or instead of an and. A test was added for this case.