### PR TITLE
Infer location of Xcode project in validate_universal_links

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ This action validates all Universal Link domains configured in a project without
 It validates both Branch and non-Branch domains.
 
 ```ruby
-validate_universal_links xcodeproj: "MyIOSApp.xcodeproj"
+validate_universal_links
 ```
 
 ## Example

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,5 +10,5 @@ end
 
 desc "Validate Universal Link settings for a project"
 lane :validate do
-  validate_universal_links xcodeproj: "examples/ios/BranchPluginExample/BranchPluginExample.xcodeproj"
+  validate_universal_links
 end

--- a/lib/fastlane/plugin/branch/actions/validate_universal_links_action.rb
+++ b/lib/fastlane/plugin/branch/actions/validate_universal_links_action.rb
@@ -6,8 +6,12 @@ module Fastlane
       def self.run(params)
         helper = Fastlane::Helper::BranchHelper
 
+        xcodeproj_path = helper.xcodeproj_path_from_params params
+        # Error reporting is done in the helper.
+        return false if xcodeproj_path.nil?
+
         # raises
-        xcodeproj = Xcodeproj::Project.open params[:xcodeproj]
+        xcodeproj = Xcodeproj::Project.open xcodeproj_path
 
         target = params[:target] # may be nil
 
@@ -43,7 +47,13 @@ module Fastlane
       def self.example_code
         [
           <<-EOF
-            validate_universal_links xcodeproj: "MyIOSApp.xcodeproj"
+            validate_universal_links
+          EOF,
+          <<-EOF
+            validate_universal_links xcodeproj: "MyProject.xcodeproj"
+          EOF,
+          <<-EOF
+            validate_universal_links xcodeproj: "MyProject.xcodeproj", target: "MyProject"
           EOF
         ]
       end
@@ -53,7 +63,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :xcodeproj,
                                   env_name: "BRANCH_XCODEPROJ",
                                description: "Path to an Xcode project to modify",
-                                  optional: false,
+                                  optional: true,
                                       type: String),
           FastlaneCore::ConfigItem.new(key: :target,
                                   env_name: "BRANCH_TARGET",


### PR DESCRIPTION
Many Fastlane actions that act on Xcode projects don't require the `:xcodeproj` parameter to operate. The code from `commit_version_bump` was adapted to find the only project if one exists, and the `:xcodeproj` parameter was made optional.

Now all that's required to use this action in a lane is:

```Ruby
validate_universal_links
```

The optional `:xcodeproj` and `:target` parameters can be used if desired or necessary.

The `validate_universal_links` action supports iOS only. The `setup_branch` action supports both Android and iOS. It's probably best to assume Android only if `:xcodeproj` is missing, but that assumption can be revisited.