### PR TITLE
Added :force option

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Available options:
 |:target|BRANCH_TARGET|Name of the target to use in the Xcode project (iOS only; optional)|string||
 |:update_bundle_and_team_ids|BRANCH_UPDATE_BUNDLE_AND_TEAM_IDS|If true, changes the bundle and team identifiers in the Xcode project to match the AASA file. Mainly useful for sample apps. (iOS only)|boolean|false|
 |:remove_existing_domains|BRANCH_REMOVE_EXISTING_DOMAINS|If true, any domains currently configured in the Xcode project or Android manifest will be removed before adding the domains specified by the arguments. Mainly useful for sample apps.|boolean|false|
+|:force|BRANCH_FORCE_UPDATE|Update project(s) even if Universal Link validation fails|boolean|false|
 
 Individually, all parameters are optional, but the following conditions apply:
 

--- a/lib/fastlane/plugin/branch/actions/setup_branch_action.rb
+++ b/lib/fastlane/plugin/branch/actions/setup_branch_action.rb
@@ -33,7 +33,7 @@ module Fastlane
           else
             UI.error "Universal Link configuration failed validation."
             helper.errors.each { |error| UI.error " #{error}" }
-            return
+            return unless params[:force]
           end
 
           # the following calls can all raise IOError
@@ -155,6 +155,12 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :remove_existing_domains,
                                   env_name: "BRANCH_REMOVE_EXISTING_DOMAINS",
                                description: "If set to true, removes any existing domains before adding Branch domains",
+                                  optional: true,
+                             default_value: false,
+                                 is_string: false),
+          FastlaneCore::ConfigItem.new(key: :force,
+                                  env_name: "BRANCH_FORCE_UPDATE",
+                               description: "Update project(s) even if Universal Link validation fails",
                                   optional: true,
                              default_value: false,
                                  is_string: false)


### PR DESCRIPTION
By default the `setup_branch` action doesn't make any modifications (to either platform) unless the Universal Link validation passes (if :xcodeproj is specified). This allows you to force the update and go fix the AASA/Dashboard configuration later.