### PR TITLE
Added an optional Branchfile in the vein of Scanfile, Gymfile, et al.

### DIFF
--- a/Branchfile
+++ b/Branchfile
@@ -1,0 +1,10 @@
+# Branch configuration defaults
+
+live_key "key_live_feebgAAhbH9Tv85H5wLQhpdaefiZv5Dv"
+# This app is not currently set up properly for test in the Dashboard. Don't include
+# test_key in the project for now.
+# test_key "key_test_hdcBLUy1xZ1JD0tKg7qrLcgirFmPPVJc"
+app_link_subdomain "bnctestbed"
+uri_scheme "branchtest"
+android_project_path "examples/android/BranchPluginExample"
+xcodeproj "examples/ios/BranchPluginExample/BranchPluginExample.xcodeproj"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,23 +1,11 @@
 desc "Add Branch keys and Universal Link domains to BranchPluginExample"
 lane :update do
-  # This app is not currently set up properly for test in the Dashboard. Don't include
-  # :test_key in the project for now.
-  setup_branch live_key: "key_live_feebgAAhbH9Tv85H5wLQhpdaefiZv5Dv",
-     # test_key: "key_test_hdcBLUy1xZ1JD0tKg7qrLcgirFmPPVJc",
-     app_link_subdomain: "bnctestbed",
-             uri_scheme: "branchtest",
-   android_project_path: "examples/android/BranchPluginExample",
-              xcodeproj: "examples/ios/BranchPluginExample/BranchPluginExample.xcodeproj"
+  setup_branch
 end
 
 desc "Add Branch keys and Universal Link domains to BranchPluginExample and commit to Git"
 lane :update_and_commit do
-  setup_branch live_key: "key_live_feebgAAhbH9Tv85H5wLQhpdaefiZv5Dv",
-     app_link_subdomain: "bnctestbed",
-             uri_scheme: "branchtest",
-   android_project_path: "examples/android/BranchPluginExample",
-              xcodeproj: "examples/ios/BranchPluginExample/BranchPluginExample.xcodeproj",
-                 commit: true # Use a string here for a custom commit message
+  setup_branch commit: true # Use a string here for a custom commit message
 end
 
 desc "Validate Universal Link settings for a project"

--- a/lib/fastlane/plugin/branch/actions/setup_branch_action.rb
+++ b/lib/fastlane/plugin/branch/actions/setup_branch_action.rb
@@ -5,6 +5,9 @@ module Fastlane
     class SetupBranchAction < Action
       # rubocop: disable Metrics/PerceivedComplexity
       def self.run(params)
+        # First augment with any defaults from Branchfile, if present
+        params.load_configuration_file("Branchfile")
+
         helper = Helper::BranchHelper
 
         keys = helper.keys_from_params params


### PR DESCRIPTION
Added support for an optional Branchfile containing configuration parameters. See the Branchfile at the root of the repo for an example.

Currently this is only used with the `setup_branch` action, which has quite a few parameters.