### PR TITLE
Added a validate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Available options:
 |:target|Name of the target to use in the Xcode project (iOS only; optional)|BRANCH_TARGET|string||
 |:update_bundle_and_team_ids|If true, changes the bundle and team identifiers in the Xcode project to match the AASA file. Mainly useful for sample apps. (iOS only)|BRANCH_UPDATE_BUNDLE_AND_TEAM_IDS|boolean|false|
 |:remove_existing_domains|If true, any domains currently configured in the Xcode project or Android manifest will be removed before adding the domains specified by the arguments. Mainly useful for sample apps.|BRANCH_REMOVE_EXISTING_DOMAINS|boolean|false|
+|:validate|Determines whether to validate the resulting Universal Link configuration before modifying the project|BRANCH_VALIDATE|boolean|true|
 |:force|Update project(s) even if Universal Link validation fails|BRANCH_FORCE_UPDATE|boolean|false|
 |:commit|Set to true to commit changes to Git; set to a string to commit with a custom message|boolean or string|BRANCH_COMMIT_CHANGES|false|
 

--- a/lib/fastlane/plugin/branch/actions/setup_branch_action.rb
+++ b/lib/fastlane/plugin/branch/actions/setup_branch_action.rb
@@ -33,9 +33,10 @@ module Fastlane
 
           if params[:update_bundle_and_team_ids]
             helper.update_team_and_bundle_ids_from_aasa_file xcodeproj, target, domains.first
-          elsif helper.validate_team_and_bundle_ids_from_aasa_files xcodeproj, target, domains, params[:remove_existing_domains]
+          elsif params[:validate] &&
+                helper.validate_team_and_bundle_ids_from_aasa_files(xcodeproj, target, domains, params[:remove_existing_domains])
             UI.message "Universal Link configuration passed validation. ✅"
-          else
+          elsif params[:validate]
             UI.error "Universal Link configuration failed validation."
             helper.errors.each { |error| UI.error " #{error}" }
             return unless params[:force]
@@ -174,6 +175,11 @@ module Fastlane
                                description: "If set to true, removes any existing domains before adding Branch domains",
                                   optional: true,
                              default_value: false,
+                                 is_string: false),
+          FastlaneCore::ConfigItem.new(key: :validate,
+                                  env_name: "BRANCH_VALIDATE",
+                               description: "Determines whether to validate the resulting Universal Link configuration before modifying the project",
+                             default_value: true,
                                  is_string: false),
           FastlaneCore::ConfigItem.new(key: :force,
                                   env_name: "BRANCH_FORCE_UPDATE",


### PR DESCRIPTION
Can now specify `validate: false` when modifying an Xcode project to make validation optional. Can also use `force: true` to report errors but change anyway.