### PR TITLE
Signed AASA correction

### DIFF
--- a/lib/fastlane/plugin/branch/helper/ios_helper.rb
+++ b/lib/fastlane/plugin/branch/helper/ios_helper.rb
@@ -207,7 +207,7 @@ module Fastlane
               cert_store = OpenSSL::X509::Store.new
               signature = OpenSSL::PKCS7.new response.body
               # raises
-              signature.verify [http.peer_cert], cert_store, nil, OpenSSL::PKCS7::NOVERIFY
+              signature.verify nil, cert_store, nil, OpenSSL::PKCS7::NOVERIFY
               data = signature.data
             else
               @error << "[#{domain}] Unsigned AASA files must be served via HTTPS" and next if uri.scheme == "http"

--- a/lib/fastlane/plugin/branch/helper/ios_helper.rb
+++ b/lib/fastlane/plugin/branch/helper/ios_helper.rb
@@ -173,9 +173,9 @@ module Fastlane
       def contents_of_aasa_file(domain)
         uris = [
           URI("https://#{domain}/.well-known/apple-app-site-association"),
-          URI("https://#{domain}/apple-app-site-association"),
-          URI("http://#{domain}/.well-known/apple-app-site-association"),
-          URI("http://#{domain}/apple-app-site-association")
+          URI("https://#{domain}/apple-app-site-association")
+          # URI("http://#{domain}/.well-known/apple-app-site-association"),
+          # URI("http://#{domain}/apple-app-site-association")
         ]
 
         data = nil


### PR DESCRIPTION
Signed AASA files do not have to use the TLS cert from the domain. HTTP may have been supported at one time, but does not appear to be supported now.