### PR TITLE
Source code patching

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ Available options:
 |:force|Update project(s) even if Universal Link validation fails|BRANCH_FORCE_UPDATE|boolean|false|
 |:commit|Set to true to commit changes to Git; set to a string to commit with a custom message|BRANCH_COMMIT_CHANGES|boolean or string|false|
 |:frameworks|A list of system frameworks to add to the target that uses the Branch SDK (iOS only)|BRANCH_FRAMEWORKS|array|[]|
+|:add_sdk|Set to false to disable automatic integration of the Branch SDK|BRANCH_ADD_SDK|boolean|true|
+|:podfile|Path to a Podfile to update (iOS only)|BRANCH_PODFILE|string||
+|:patch_source|Set to false to disable automatic source-code patching|BRANCH_PATCH_SOURCE|boolean|true|
 
 Individually, all parameters are optional, but the following conditions apply:
 

--- a/examples/ios/BranchPluginExampleObjc/.gitignore
+++ b/examples/ios/BranchPluginExampleObjc/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+Pods
+xcuserdata
+project.xcworkspace

--- a/examples/ios/BranchPluginExampleObjc/BranchPluginExampleObjc.xcodeproj/project.pbxproj
+++ b/examples/ios/BranchPluginExampleObjc/BranchPluginExampleObjc.xcodeproj/project.pbxproj
@@ -1,0 +1,404 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		33900073173019FB089C918E /* Pods_BranchPluginExampleObjc.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 96AA24C1214C4B16D45247D7 /* Pods_BranchPluginExampleObjc.framework */; };
+		7BC2F8ED1F5B4ACE001358F8 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BC2F8EC1F5B4ACE001358F8 /* main.m */; };
+		7BC2F8F01F5B4ACE001358F8 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BC2F8EF1F5B4ACE001358F8 /* AppDelegate.m */; };
+		7BC2F8F31F5B4ACE001358F8 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BC2F8F21F5B4ACE001358F8 /* ViewController.m */; };
+		7BC2F8F61F5B4ACE001358F8 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7BC2F8F41F5B4ACE001358F8 /* Main.storyboard */; };
+		7BC2F8F81F5B4ACE001358F8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7BC2F8F71F5B4ACE001358F8 /* Assets.xcassets */; };
+		7BC2F8FB1F5B4ACE001358F8 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7BC2F8F91F5B4ACE001358F8 /* LaunchScreen.storyboard */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		308705AFEB4240F708A2FC7B /* Pods-BranchPluginExampleObjc.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BranchPluginExampleObjc.release.xcconfig"; path = "Pods/Target Support Files/Pods-BranchPluginExampleObjc/Pods-BranchPluginExampleObjc.release.xcconfig"; sourceTree = "<group>"; };
+		52FAF09A2888926773D5E936 /* Pods-BranchPluginExampleObjc.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BranchPluginExampleObjc.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BranchPluginExampleObjc/Pods-BranchPluginExampleObjc.debug.xcconfig"; sourceTree = "<group>"; };
+		7BC2F8E81F5B4ACE001358F8 /* BranchPluginExampleObjc.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BranchPluginExampleObjc.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		7BC2F8EC1F5B4ACE001358F8 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		7BC2F8EE1F5B4ACE001358F8 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		7BC2F8EF1F5B4ACE001358F8 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		7BC2F8F11F5B4ACE001358F8 /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		7BC2F8F21F5B4ACE001358F8 /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		7BC2F8F51F5B4ACE001358F8 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		7BC2F8F71F5B4ACE001358F8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		7BC2F8FA1F5B4ACE001358F8 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		7BC2F8FC1F5B4ACE001358F8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		96AA24C1214C4B16D45247D7 /* Pods_BranchPluginExampleObjc.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BranchPluginExampleObjc.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		7BC2F8E51F5B4ACE001358F8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				33900073173019FB089C918E /* Pods_BranchPluginExampleObjc.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		18B358C63CE026E4CC89E678 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				52FAF09A2888926773D5E936 /* Pods-BranchPluginExampleObjc.debug.xcconfig */,
+				308705AFEB4240F708A2FC7B /* Pods-BranchPluginExampleObjc.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		4890AC49B4B687DACE2CB1E1 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				96AA24C1214C4B16D45247D7 /* Pods_BranchPluginExampleObjc.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		7BC2F8DF1F5B4ACE001358F8 = {
+			isa = PBXGroup;
+			children = (
+				7BC2F8EA1F5B4ACE001358F8 /* BranchPluginExampleObjc */,
+				7BC2F8E91F5B4ACE001358F8 /* Products */,
+				18B358C63CE026E4CC89E678 /* Pods */,
+				4890AC49B4B687DACE2CB1E1 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		7BC2F8E91F5B4ACE001358F8 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				7BC2F8E81F5B4ACE001358F8 /* BranchPluginExampleObjc.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		7BC2F8EA1F5B4ACE001358F8 /* BranchPluginExampleObjc */ = {
+			isa = PBXGroup;
+			children = (
+				7BC2F8EE1F5B4ACE001358F8 /* AppDelegate.h */,
+				7BC2F8EF1F5B4ACE001358F8 /* AppDelegate.m */,
+				7BC2F8F11F5B4ACE001358F8 /* ViewController.h */,
+				7BC2F8F21F5B4ACE001358F8 /* ViewController.m */,
+				7BC2F8F41F5B4ACE001358F8 /* Main.storyboard */,
+				7BC2F8F71F5B4ACE001358F8 /* Assets.xcassets */,
+				7BC2F8F91F5B4ACE001358F8 /* LaunchScreen.storyboard */,
+				7BC2F8FC1F5B4ACE001358F8 /* Info.plist */,
+				7BC2F8EB1F5B4ACE001358F8 /* Supporting Files */,
+			);
+			path = BranchPluginExampleObjc;
+			sourceTree = "<group>";
+		};
+		7BC2F8EB1F5B4ACE001358F8 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				7BC2F8EC1F5B4ACE001358F8 /* main.m */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		7BC2F8E71F5B4ACE001358F8 /* BranchPluginExampleObjc */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7BC2F8FF1F5B4ACE001358F8 /* Build configuration list for PBXNativeTarget "BranchPluginExampleObjc" */;
+			buildPhases = (
+				F930046005B27086D3A8BDDD /* [CP] Check Pods Manifest.lock */,
+				7BC2F8E41F5B4ACE001358F8 /* Sources */,
+				7BC2F8E51F5B4ACE001358F8 /* Frameworks */,
+				7BC2F8E61F5B4ACE001358F8 /* Resources */,
+				5795C754F1B1D888374E53F9 /* [CP] Embed Pods Frameworks */,
+				F25C04C35AA71CD13F60B3FD /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BranchPluginExampleObjc;
+			productName = BranchPluginExampleObjc;
+			productReference = 7BC2F8E81F5B4ACE001358F8 /* BranchPluginExampleObjc.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		7BC2F8E01F5B4ACE001358F8 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0830;
+				ORGANIZATIONNAME = "Branch Metrics";
+				TargetAttributes = {
+					7BC2F8E71F5B4ACE001358F8 = {
+						CreatedOnToolsVersion = 8.3.3;
+						DevelopmentTeam = R63EM248DP;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 7BC2F8E31F5B4ACE001358F8 /* Build configuration list for PBXProject "BranchPluginExampleObjc" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 7BC2F8DF1F5B4ACE001358F8;
+			productRefGroup = 7BC2F8E91F5B4ACE001358F8 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				7BC2F8E71F5B4ACE001358F8 /* BranchPluginExampleObjc */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		7BC2F8E61F5B4ACE001358F8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7BC2F8FB1F5B4ACE001358F8 /* LaunchScreen.storyboard in Resources */,
+				7BC2F8F81F5B4ACE001358F8 /* Assets.xcassets in Resources */,
+				7BC2F8F61F5B4ACE001358F8 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		5795C754F1B1D888374E53F9 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-BranchPluginExampleObjc/Pods-BranchPluginExampleObjc-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/AFNetworking/AFNetworking.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AFNetworking.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-BranchPluginExampleObjc/Pods-BranchPluginExampleObjc-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F25C04C35AA71CD13F60B3FD /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-BranchPluginExampleObjc/Pods-BranchPluginExampleObjc-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F930046005B27086D3A8BDDD /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-BranchPluginExampleObjc-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		7BC2F8E41F5B4ACE001358F8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7BC2F8F31F5B4ACE001358F8 /* ViewController.m in Sources */,
+				7BC2F8F01F5B4ACE001358F8 /* AppDelegate.m in Sources */,
+				7BC2F8ED1F5B4ACE001358F8 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		7BC2F8F41F5B4ACE001358F8 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				7BC2F8F51F5B4ACE001358F8 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		7BC2F8F91F5B4ACE001358F8 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				7BC2F8FA1F5B4ACE001358F8 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		7BC2F8FD1F5B4ACE001358F8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		7BC2F8FE1F5B4ACE001358F8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		7BC2F9001F5B4ACE001358F8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 52FAF09A2888926773D5E936 /* Pods-BranchPluginExampleObjc.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = R63EM248DP;
+				INFOPLIST_FILE = BranchPluginExampleObjc/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = io.branch.BranchPluginExampleObjc;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		7BC2F9011F5B4ACE001358F8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 308705AFEB4240F708A2FC7B /* Pods-BranchPluginExampleObjc.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = R63EM248DP;
+				INFOPLIST_FILE = BranchPluginExampleObjc/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = io.branch.BranchPluginExampleObjc;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		7BC2F8E31F5B4ACE001358F8 /* Build configuration list for PBXProject "BranchPluginExampleObjc" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7BC2F8FD1F5B4ACE001358F8 /* Debug */,
+				7BC2F8FE1F5B4ACE001358F8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7BC2F8FF1F5B4ACE001358F8 /* Build configuration list for PBXNativeTarget "BranchPluginExampleObjc" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7BC2F9001F5B4ACE001358F8 /* Debug */,
+				7BC2F9011F5B4ACE001358F8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 7BC2F8E01F5B4ACE001358F8 /* Project object */;
+}

--- a/examples/ios/BranchPluginExampleObjc/BranchPluginExampleObjc.xcodeproj/project.pbxproj
+++ b/examples/ios/BranchPluginExampleObjc/BranchPluginExampleObjc.xcodeproj/project.pbxproj
@@ -360,7 +360,7 @@
 				DEVELOPMENT_TEAM = R63EM248DP;
 				INFOPLIST_FILE = BranchPluginExampleObjc/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = io.branch.BranchPluginExampleObjc;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.branch.sdk.Branch-TestBed";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -373,7 +373,7 @@
 				DEVELOPMENT_TEAM = R63EM248DP;
 				INFOPLIST_FILE = BranchPluginExampleObjc/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = io.branch.BranchPluginExampleObjc;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.branch.sdk.Branch-TestBed";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -397,6 +397,7 @@
 				7BC2F9011F5B4ACE001358F8 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/examples/ios/BranchPluginExampleObjc/BranchPluginExampleObjc.xcworkspace/contents.xcworkspacedata
+++ b/examples/ios/BranchPluginExampleObjc/BranchPluginExampleObjc.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:BranchPluginExampleObjc.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/examples/ios/BranchPluginExampleObjc/BranchPluginExampleObjc/AppDelegate.h
+++ b/examples/ios/BranchPluginExampleObjc/BranchPluginExampleObjc/AppDelegate.h
@@ -1,0 +1,16 @@
+//
+//  AppDelegate.h
+//  BranchPluginExampleObjc
+//
+//  Created by Jimmy Dee on 9/2/17.
+//  Copyright © 2017 Branch Metrics. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+@end
+

--- a/examples/ios/BranchPluginExampleObjc/BranchPluginExampleObjc/AppDelegate.m
+++ b/examples/ios/BranchPluginExampleObjc/BranchPluginExampleObjc/AppDelegate.m
@@ -1,0 +1,17 @@
+//
+//  AppDelegate.m
+//  BranchPluginExampleObjc
+//
+//  Created by Jimmy Dee on 9/2/17.
+//  Copyright © 2017 Branch Metrics. All rights reserved.
+//
+
+#import "AppDelegate.h"
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    return YES;
+}
+
+@end

--- a/examples/ios/BranchPluginExampleObjc/BranchPluginExampleObjc/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/examples/ios/BranchPluginExampleObjc/BranchPluginExampleObjc/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,68 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/examples/ios/BranchPluginExampleObjc/BranchPluginExampleObjc/Base.lproj/LaunchScreen.storyboard
+++ b/examples/ios/BranchPluginExampleObjc/BranchPluginExampleObjc/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11134" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11106"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Llm-lL-Icb"/>
+                        <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/examples/ios/BranchPluginExampleObjc/BranchPluginExampleObjc/Base.lproj/Main.storyboard
+++ b/examples/ios/BranchPluginExampleObjc/BranchPluginExampleObjc/Base.lproj/Main.storyboard
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11134" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11106"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
+                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/examples/ios/BranchPluginExampleObjc/BranchPluginExampleObjc/Info.plist
+++ b/examples/ios/BranchPluginExampleObjc/BranchPluginExampleObjc/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/examples/ios/BranchPluginExampleObjc/BranchPluginExampleObjc/ViewController.h
+++ b/examples/ios/BranchPluginExampleObjc/BranchPluginExampleObjc/ViewController.h
@@ -1,0 +1,14 @@
+//
+//  ViewController.h
+//  BranchPluginExampleObjc
+//
+//  Created by Jimmy Dee on 9/2/17.
+//  Copyright © 2017 Branch Metrics. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface ViewController : UIViewController
+
+@end
+

--- a/examples/ios/BranchPluginExampleObjc/BranchPluginExampleObjc/ViewController.m
+++ b/examples/ios/BranchPluginExampleObjc/BranchPluginExampleObjc/ViewController.m
@@ -1,0 +1,17 @@
+//
+//  ViewController.m
+//  BranchPluginExampleObjc
+//
+//  Created by Jimmy Dee on 9/2/17.
+//  Copyright © 2017 Branch Metrics. All rights reserved.
+//
+
+#import "ViewController.h"
+
+@interface ViewController ()
+
+@end
+
+@implementation ViewController
+
+@end

--- a/examples/ios/BranchPluginExampleObjc/BranchPluginExampleObjc/main.m
+++ b/examples/ios/BranchPluginExampleObjc/BranchPluginExampleObjc/main.m
@@ -1,0 +1,16 @@
+//
+//  main.m
+//  BranchPluginExampleObjc
+//
+//  Created by Jimmy Dee on 9/2/17.
+//  Copyright © 2017 Branch Metrics. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[]) {
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    }
+}

--- a/examples/ios/BranchPluginExampleObjc/Podfile
+++ b/examples/ios/BranchPluginExampleObjc/Podfile
@@ -1,0 +1,6 @@
+use_frameworks!
+platform :ios, "8.0"
+
+pod "AFNetworking"
+
+target "BranchPluginExampleObjc"

--- a/examples/ios/BranchPluginExampleObjc/Podfile.lock
+++ b/examples/ios/BranchPluginExampleObjc/Podfile.lock
@@ -1,0 +1,26 @@
+PODS:
+  - AFNetworking (3.1.0):
+    - AFNetworking/NSURLSession (= 3.1.0)
+    - AFNetworking/Reachability (= 3.1.0)
+    - AFNetworking/Security (= 3.1.0)
+    - AFNetworking/Serialization (= 3.1.0)
+    - AFNetworking/UIKit (= 3.1.0)
+  - AFNetworking/NSURLSession (3.1.0):
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+  - AFNetworking/Reachability (3.1.0)
+  - AFNetworking/Security (3.1.0)
+  - AFNetworking/Serialization (3.1.0)
+  - AFNetworking/UIKit (3.1.0):
+    - AFNetworking/NSURLSession
+
+DEPENDENCIES:
+  - AFNetworking
+
+SPEC CHECKSUMS:
+  AFNetworking: 5e0e199f73d8626b11e79750991f5d173d1f8b67
+
+PODFILE CHECKSUM: 2f4db3bb6fdde5ed89e00c5a42332e195dc6df7d
+
+COCOAPODS: 1.3.1

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -8,6 +8,11 @@ lane :setup_and_commit do
   setup_branch commit: true # Use a string here for a custom commit message
 end
 
+desc "Set up the BranchPluginExampleObjc"
+lane :setup_objc do
+  setup_branch xcodeproj: "examples/ios/BranchPluginExampleObjc/BranchPluginExampleObjc.xcodeproj"
+end
+
 desc "Validate Universal Link settings for a project"
 lane :validate do
   # The :domains parameter is optional.

--- a/lib/fastlane/plugin/branch/actions/setup_branch_action.rb
+++ b/lib/fastlane/plugin/branch/actions/setup_branch_action.rb
@@ -53,7 +53,7 @@ module Fastlane
 
           xcodeproj.save
 
-          # helper.patch_app_delegate_swift xcodeproj
+          patch_source xcodeproj if params[:patch_source]
         end
 
         if params[:android_project_path] || params[:android_manifest_path]
@@ -216,7 +216,13 @@ module Fastlane
                                description: "Path to a Podfile to update (iOS only)",
                                   optional: true,
                              default_value: nil,
-                                      type: String)
+                                      type: String),
+          FastlaneCore::ConfigItem.new(key: :patch_source,
+                                  env_name: "BRANCH_PATCH_SOURCE",
+                               description: "Set to false to disable automatic source-code patching",
+                                  optional: true,
+                             default_value: true,
+                                 is_string: false)
         ]
       end
 
@@ -248,6 +254,10 @@ module Fastlane
           # 5. If so, add the Pods folder to the commit (in case :commit param specified)
           helper.add_change pods_folder_path
           other_action.git_add path: pods_folder_path
+        end
+
+        def patch_source(xcodeproj)
+          helper.patch_app_delegate_swift xcodeproj
         end
 
         def helper

--- a/lib/fastlane/plugin/branch/actions/setup_branch_action.rb
+++ b/lib/fastlane/plugin/branch/actions/setup_branch_action.rb
@@ -257,7 +257,7 @@ module Fastlane
         end
 
         def patch_source(xcodeproj)
-          helper.patch_app_delegate_swift xcodeproj
+          helper.patch_app_delegate_swift(xcodeproj) || helper.patch_app_delegate_objc(xcodeproj)
         end
 
         def helper

--- a/lib/fastlane/plugin/branch/helper/configuration_helper.rb
+++ b/lib/fastlane/plugin/branch/helper/configuration_helper.rb
@@ -87,9 +87,9 @@ module Fastlane
         return nil unless add_sdk? params
 
         # Use the :podfile parameter if present
-        podfile_path = File.expand_path params[:podfile], Bundler.root
-        if podfile_path
-          UI.user_error! ":podfile argument must specify a path ending in '/Podfile'" unless podfile_path =~ %r{/Podfile$}
+        if params[:podfile]
+          UI.user_error! ":podfile argument must specify a path ending in '/Podfile'" unless params[:podfile] =~ %r{/Podfile$}
+          podfile_path = File.expand_path params[:podfile], Bundler.root
           return podfile_path if File.exist? podfile_path
           UI.user_error! "#{podfile_path} not found"
         end

--- a/lib/fastlane/plugin/branch/helper/ios_helper.rb
+++ b/lib/fastlane/plugin/branch/helper/ios_helper.rb
@@ -356,8 +356,9 @@ module Fastlane
           offset: 0
         )
 
+        # TODO: This is Swift 3. Support other versions, esp. 4.
         init_session_text = <<-EOF
-        Branch.getInstance().initSession(with: launchOptions) {
+        Branch.getInstance().initSession(launchOptions: launchOptions) {
             universalObject, linkProperties, error in
 
             // TODO: Route Branch links

--- a/lib/fastlane/plugin/branch/helper/ios_helper.rb
+++ b/lib/fastlane/plugin/branch/helper/ios_helper.rb
@@ -389,17 +389,17 @@ module Fastlane
 
         Actions::PatchAction.run(
           files: app_delegate_objc_path,
-          regexp: /@import|#import/,
+          regexp: /^\s+@import|^\s+#import.*$/,
           text: "\n#import <Branch/Branch.h>",
           mode: :prepend,
           offset: 0
         )
 
         init_session_text = <<-EOF
-        [[Branch getInstance] initSessionWithLaunchOptions:launchOptions
-                              andRegisterDeepLinkHandlerUsingBranchUniversalObject:^(BranchUniversalObject *universalObject, BranchLinkProperties *linkProperties, NSError *error){
-            // TODO: Route Branch links
-        }];
+    [[Branch getInstance] initSessionWithLaunchOptions:launchOptions
+        andRegisterDeepLinkHandlerUsingBranchUniversalObject:^(BranchUniversalObject *universalObject, BranchLinkProperties *linkProperties, NSError *error){
+        // TODO: Route Branch links
+    }];
         EOF
 
         Actions::PatchAction.run(

--- a/lib/fastlane/plugin/branch/helper/ios_helper.rb
+++ b/lib/fastlane/plugin/branch/helper/ios_helper.rb
@@ -339,9 +339,12 @@ module Fastlane
 
       def patch_app_delegate_swift(project)
         app_delegate_swift = project.files.find { |f| f.path =~ /AppDelegate.swift$/ }
-        raise "*AppDelegate.swift not found in project" if app_delegate_swift.nil?
+        return false if app_delegate_swift.nil?
 
         app_delegate_swift_path = app_delegate_swift.real_path.to_s
+
+        app_delegate = File.open(app_delegate_swift_path, &:read)
+        return false if app_delegate =~ /import\s+Branch/
 
         UI.message "Patching #{app_delegate_swift_path}"
 
@@ -356,6 +359,8 @@ module Fastlane
         init_session_text = <<-EOF
         Branch.getInstance().initSession(with: launchOptions) {
             universalObject, linkProperties, error in
+
+            // TODO: Route Branch links
         }
         EOF
 
@@ -368,6 +373,7 @@ module Fastlane
         )
 
         add_change app_delegate_swift_path
+        true
       end
 
       def patch_podfile(podfile_path)


### PR DESCRIPTION
Introduced source-code patching for iOS. An import and a call to `initSession` are added to the AppDelegate by default. Disable with `patch_source: false`.

Also fixed a bug when the `:podfile` option is absent.